### PR TITLE
First cut with toolips.  Silly, may change to info buttons.

### DIFF
--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -49,11 +49,10 @@ function Legend(props: LegendProps) {
   }, [dataTypeIndex, speciesIndex]);
 
   return (
-    <div className="Legend">
+    <div style={{background:"lightgrey", padding:10, borderRadius:10}}>
       <Grid align='stretch'>
         <Grid.Col span={4}>
           <div
-            className="Legend-innerGradient"
             style={{
               display: 'inline-block',
               width: '14px',

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { useEffect, useState } from 'react';
-import { Grid } from '@mantine/core';
+import { Grid, Tooltip } from '@mantine/core';
 import { getScalingFilename, dataInfo} from '../hooks/dataUrl';
 
 // Interface for the Legend 
@@ -65,14 +65,15 @@ function Legend(props: LegendProps) {
         </Grid.Col>
         <Grid.Col span={8} >
           {/* PAM - this is a little hacky, couldn't get lowLabel to align "bottom"
-             so made it so the midLabel would push it to the right place. */ }
+            so made it so the midLabel would push it to the right place. */ }
           <div style={{alignContent:"top"}}>{highLabel}</div>
           <div style={{height:'75%', alignContent:"center"}}>{midLabel}</div>
           <div>{lowLabel}</div>
         </Grid.Col>
       </Grid>
-      <div style={{textAlign:"center"}}>{dataInfo[dataTypeIndex].units}</div>
-
+      <Tooltip label='Text to explain scaling'>
+        <div style={{textAlign:"center"}}>{dataInfo[dataTypeIndex].units}</div>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { useEffect, useState } from 'react';
-import { Grid, Tooltip } from '@mantine/core';
+import { Grid, Stack, Tooltip } from '@mantine/core';
 import { getScalingFilename, dataInfo} from '../hooks/dataUrl';
 
 // Interface for the Legend 
@@ -49,7 +49,7 @@ function Legend(props: LegendProps) {
   }, [dataTypeIndex, speciesIndex]);
 
   return (
-    <div style={{background:"lightgrey", padding:10, borderRadius:10}}>
+    <div style={{background:"lightgrey", width: '100px', padding:10, borderRadius:10}}>
       <Grid align='stretch'>
         <Grid.Col span={4}>
           <div
@@ -63,11 +63,11 @@ function Legend(props: LegendProps) {
           />
         </Grid.Col>
         <Grid.Col span={8} >
-          {/* PAM - this is a little hacky, couldn't get lowLabel to align "bottom"
-            so made it so the midLabel would push it to the right place. */ }
-          <div style={{alignContent:"top"}}>{highLabel}</div>
-          <div style={{height:'75%', alignContent:"center"}}>{midLabel}</div>
-          <div>{lowLabel}</div>
+          <Stack h={200} align='flex-start'  justify='space-between' gap='xl'>
+            <div>{highLabel}</div>
+            <div>{midLabel}</div>
+            <div>{lowLabel}</div>
+          </Stack>
         </Grid.Col>
       </Grid>
       <Tooltip label='Text to explain scaling'>

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -13,11 +13,13 @@
         left: 2%;
         width: 96%;
         height: 96%;
-        background-color: pink;
-        opacity: 0.6;
-
     }
 
+    .test {
+        background-color: pink;
+        opacity: 0.6;
+    }
+    
     .Timeline {
         background-color: white;
         height: 55px;

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -6,41 +6,19 @@
         z-index: 0;
     }
 
-    .title {
+    .widgets {
+        z-index: 10;
         position: fixed;
-        z-index: 200;
-        top: 15px;
-        left: 50%;
-        transform: translate(-50%, 0%);
-        background-color: rgb(227, 243, 250);
+        top: 2%;
+        left: 2%;
+        width: 96%;
+        height: 96%;
+        background-color: pink;
         opacity: 0.6;
-    }
 
-    .dataIndex-button {
-        position: absolute;
-        top: 100px;
-        right: 250px;
-        z-index: 400;
-    }
-
-    .speciesType-button {
-        position: absolute;
-        top: 100px;
-        right: 100px;
-        width: 140;
-        z-index: 400;
-    }
-
-    .date-button {
-        position: absolute;
-        top: 100px;
-        right: 20px;
-        z-index: 400;
     }
 
     .Timeline {
-
-        z-index: 400;
         background-color: white;
         height: 55px;
         width: 70%;
@@ -51,19 +29,6 @@
         left: 50%;
         /* bring your own prefixes */
         transform: translate(-50%, -50%);
-
-    }
-
-    .Legend {
-        position: absolute;
-        bottom: 150px;
-        left: 20px;
-        z-index: 400;
-        border-radius: 10px;
-        padding: 10px;
-        height: 280px; 
-        width: 100px; 
-        background-color: lightgrey;
     }
 
 }

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,4 +1,4 @@
-import { Combobox, ComboboxStore, Input, InputBase, Tooltip, useCombobox } from '@mantine/core';
+import { Combobox, ComboboxStore, Grid, Input, InputBase, Tooltip, useCombobox } from '@mantine/core';
 import { MapContainer, TileLayer, ImageOverlay } from 'react-leaflet';
 import { forwardRef, useState, useEffect } from 'react';
 import { imageURL, getScalingFilename, dataInfo} from '../hooks/dataUrl';
@@ -170,14 +170,6 @@ function Home(this: any) {
   // Here is where you list the components and elements that you want rendered. 
   return (
     <div className="Home">
-      <div className="title">
-        <div style={{textAlign:"center", fontSize:60, fontWeight:"bold"}}>Avian Influenza</div>
-        <div style={{textAlign:"center", fontSize:30, fontWeight:"bold"}}>{dataInfo[dataIndex].label} of the {taxa[speciesIndex].label}</div>
-      </div>
-      {/* Calls the custom timeline component with the current week onChange function as parameters */}
-      <Timeline week={week} onChangeWeek={checkImageAndUpdate} />
-      {/* Calls the custom legend component with the data type and species type as parameters. */}
-      <Legend dataTypeIndex={dataIndex} speciesIndex={speciesIndex} />
       {/* Creates a map using the leaflet component */}
       <MapContainer
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -196,16 +188,6 @@ function Home(this: any) {
           // @ts-ignore
           attribution='Abundance data provided by <a target="_blank" href="https://ebird.org/science/status-and-trends ">Cornell Lab of Ornithology - eBird</a> | <a target="_blank" href="https://birdflow-science.github.io/"> BirdFlow </a>'
         />
-        {/* Dropdown for data type */}
-        <Tooltip className="dataIndex-button" label='Types of data sets'>
-          <MyDataTypeComponent />
-        </Tooltip>
-           
-
-        {/* The dropdown for the species type */}
-        <Tooltip className="speciesType-button" label='These Species were chosen because'>
-          <MyComponent />
-        </Tooltip>
         { /* Overlays an image that contains the data to be displayed on top of the map */}
         <ImageOverlay
           url={overlayUrl}
@@ -215,6 +197,38 @@ function Home(this: any) {
           opacity={0.7}
         />
       </MapContainer>
+      <div className="widgets">
+        <Grid align='stretch'>
+          <Grid.Col span={12}>
+            <div style={{textAlign:"center", fontSize:60, fontWeight:"bold"}}>Avian Influenza</div>
+          </Grid.Col>
+          <Grid.Col span={2}>
+            {/* Dropdown for data type */}
+            <Tooltip label='Types of data sets'>
+              <MyDataTypeComponent />
+            </Tooltip>
+          </Grid.Col>
+          <Grid.Col span={2}>
+            {/* The dropdown for the species type */}
+            <Tooltip label='These Species were chosen because'>
+              <MyComponent />
+            </Tooltip>
+          </Grid.Col>
+          <Grid.Col span={4}>
+            <div style={{textAlign:"center", fontSize:30, fontWeight:"bold"}}>{dataInfo[dataIndex].label} of the {taxa[speciesIndex].label}</div>
+          </Grid.Col>
+          <Grid.Col span={4}></Grid.Col>
+          <Grid.Col span={1}></Grid.Col>
+            {/* Calls the custom legend component with the data type and species type as parameters. */}
+            <Legend dataTypeIndex={dataIndex} speciesIndex={speciesIndex} />
+          <Grid.Col span={11}></Grid.Col>
+
+        </Grid>
+        {/* Calls the custom timeline component with the current week onChange function as parameters */}
+        <Timeline week={week} onChangeWeek={checkImageAndUpdate} />
+        
+
+      </div>
     </div>
   );
 }

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,6 +1,6 @@
-import { Combobox, Input, InputBase, useCombobox } from '@mantine/core';
+import { Combobox, ComboboxStore, Input, InputBase, Tooltip, useCombobox } from '@mantine/core';
 import { MapContainer, TileLayer, ImageOverlay } from 'react-leaflet';
-import { useState, useEffect } from 'react';
+import { forwardRef, useState, useEffect } from 'react';
 import { imageURL, getScalingFilename, dataInfo} from '../hooks/dataUrl';
 import taxa from '../assets/taxa.json';
 import Timeline from '../components/Timeline';
@@ -114,7 +114,58 @@ function Home(this: any) {
       {dt.label}
     </Combobox.Option>
   ));
-  
+
+  function checkDataType(val: string, ref_combo: ComboboxStore) {
+    let index = Number.parseInt(val); 
+    checkInputTypes(index, speciesIndex);
+    ref_combo.closeDropdown();
+  }
+
+  function checkSpecies(val: string, ref_combo: ComboboxStore) {
+    let index = Number.parseInt(val); 
+    checkInputTypes(dataIndex, index);
+    ref_combo.closeDropdown();
+  }
+
+  function genericCombo(ref_combo: ComboboxStore, onSubmit: Function, label: string, options: JSX.Element[]) {
+    return (
+      <Combobox
+        store={ref_combo}
+        onOptionSubmit={(val) => {
+          onSubmit(val); 
+        }}
+      >
+        <Combobox.Target>
+          <InputBase
+            component="button"
+            type="button"
+            pointer
+            leftSection={<Combobox.Chevron />}
+            onClick={() => ref_combo.toggleDropdown()}
+            leftSectionPointerEvents="none"
+          >
+            {label || <Input.Placeholder>Pick value</Input.Placeholder>}
+          </InputBase>
+        </Combobox.Target>
+        <Combobox.Dropdown>
+          <Combobox.Options>{options}</Combobox.Options>
+        </Combobox.Dropdown>
+      </Combobox>      
+    );
+  }
+
+  const MyDataTypeComponent = forwardRef<HTMLDivElement>((props, ref) => (
+    <div ref={ref} {...props}>
+      {genericCombo(typeCombo, checkDataType, dataInfo[dataIndex].label,dataTypeOptions)}
+    </div>
+  ));
+
+  const MyComponent = forwardRef<HTMLDivElement>((props, ref) => (
+    <div ref={ref} {...props}>
+      {genericCombo(speciesCombo, checkSpecies, taxa[speciesIndex].label, speciesOptions)}
+    </div>
+  ));
+
   // PAM could consolidate a bunch of the combo box after positioning is right
   // Here is where you list the components and elements that you want rendered. 
   return (
@@ -146,61 +197,15 @@ function Home(this: any) {
           attribution='Abundance data provided by <a target="_blank" href="https://ebird.org/science/status-and-trends ">Cornell Lab of Ornithology - eBird</a> | <a target="_blank" href="https://birdflow-science.github.io/"> BirdFlow </a>'
         />
         {/* Dropdown for data type */}
-        <Combobox
-          store={typeCombo}
-          onOptionSubmit={(val) => {
-            let di = Number.parseInt(val);
-            checkInputTypes(di, speciesIndex);
-            typeCombo.closeDropdown();
-          }}
-        >
-          <Combobox.Target>
-            <InputBase
-             className="dataIndex-button"
-              component="button"
-              type="button"
-              pointer
-              leftSection={<Combobox.Chevron />}
-              onClick={() => typeCombo.toggleDropdown()}
-              leftSectionPointerEvents="none"
-            >
-              {dataInfo[dataIndex].label || <Input.Placeholder>Pick value</Input.Placeholder>}
-            </InputBase>
-          </Combobox.Target>
-
-          <Combobox.Dropdown>
-            <Combobox.Options>{dataTypeOptions}</Combobox.Options>
-          </Combobox.Dropdown>
-        </Combobox>      
+        <Tooltip className="dataIndex-button" label='Types of data sets'>
+          <MyDataTypeComponent />
+        </Tooltip>
+           
 
         {/* The dropdown for the species type */}
-        <Combobox
-          store={speciesCombo}
-          onOptionSubmit={(val) => {
-            let si = Number.parseInt(val); 
-            checkInputTypes(dataIndex, si) 
-            speciesCombo.closeDropdown();
-          }}
-        >
-          <Combobox.Target>
-            <InputBase
-             className="speciesType-button"
-              component="button"
-              type="button"
-              pointer
-              leftSection={<Combobox.Chevron />}
-              onClick={() => speciesCombo.toggleDropdown()}
-              leftSectionPointerEvents="none"
-            >
-              {taxa[speciesIndex].label || <Input.Placeholder>Pick value</Input.Placeholder>}
-            </InputBase>
-          </Combobox.Target>
-
-          <Combobox.Dropdown>
-            <Combobox.Options>{speciesOptions}</Combobox.Options>
-          </Combobox.Dropdown>
-        </Combobox>      
-
+        <Tooltip className="speciesType-button" label='These Species were chosen because'>
+          <MyComponent />
+        </Tooltip>
         { /* Overlays an image that contains the data to be displayed on top of the map */}
         <ImageOverlay
           url={overlayUrl}

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,6 +1,7 @@
-import { Combobox, ComboboxStore, Grid, Input, InputBase, Tooltip, useCombobox } from '@mantine/core';
+import { Button, Combobox, ComboboxStore, Grid, Input, InputBase, Tooltip, useCombobox } from '@mantine/core';
 import { MapContainer, TileLayer, ImageOverlay } from 'react-leaflet';
 import { forwardRef, useState, useEffect } from 'react';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { imageURL, getScalingFilename, dataInfo} from '../hooks/dataUrl';
 import taxa from '../assets/taxa.json';
 import Timeline from '../components/Timeline';
@@ -207,6 +208,8 @@ function Home(this: any) {
             <Tooltip label='Types of data sets'>
               <MyDataTypeComponent />
             </Tooltip>
+            <Button leftSection={<IconInfoCircle/>} variant='default' >
+            </Button>
           </Grid.Col>
           <Grid.Col span={2}>
             {/* The dropdown for the species type */}
@@ -218,10 +221,11 @@ function Home(this: any) {
             <div style={{textAlign:"center", fontSize:30, fontWeight:"bold"}}>{dataInfo[dataIndex].label} of the {taxa[speciesIndex].label}</div>
           </Grid.Col>
           <Grid.Col span={4}></Grid.Col>
-          <Grid.Col span={1}></Grid.Col>
+          <Grid.Col span={2}>
             {/* Calls the custom legend component with the data type and species type as parameters. */}
             <Legend dataTypeIndex={dataIndex} speciesIndex={speciesIndex} />
-          <Grid.Col span={11}></Grid.Col>
+          </Grid.Col>
+          <Grid.Col span={10}></Grid.Col>
 
         </Grid>
         {/* Calls the custom timeline component with the current week onChange function as parameters */}


### PR DESCRIPTION
Create one 'widgets' div for all of the widgets that go on top of the map.  Move most of the css code into typescript - I find it is easier to maintain in one place.  Use 'Grid' more heavily instead of px counts for placement.  Add a text for tooltips that will need to be updated.