### PR TITLE
adjust week dates

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,16 +1,17 @@
 # Avian Flu App
 
+abundance and movement dates are from https://github.com/birdflow-science/BirdFlowWork/tree/main/avian_influenza/dates
+
 ## Installing Node.js
+
 In order to run this application, you need to have to install Node.js. Follow the instructions to install it:
 https://nodejs.org/en/download/package-manager
-
 
 ## To run in dev:
 
 npm install
 
 npm run dev
-
 
 ## To create a build locally:
 
@@ -23,5 +24,3 @@ serve -s
 ## To install new packages:
 
 npm install <package> --save
-
-

--- a/src/assets/abundance_dates.json
+++ b/src/assets/abundance_dates.json
@@ -1,0 +1,262 @@
+[
+  {
+    "index": 1,
+    "date": "2022-01-04",
+    "label": "Jan 4"
+  },
+  {
+    "index": 2,
+    "date": "2022-01-11",
+    "label": "Jan 11"
+  },
+  {
+    "index": 3,
+    "date": "2022-01-18",
+    "label": "Jan 18"
+  },
+  {
+    "index": 4,
+    "date": "2022-01-25",
+    "label": "Jan 25"
+  },
+  {
+    "index": 5,
+    "date": "2022-02-01",
+    "label": "Feb 1"
+  },
+  {
+    "index": 6,
+    "date": "2022-02-08",
+    "label": "Feb 8"
+  },
+  {
+    "index": 7,
+    "date": "2022-02-15",
+    "label": "Feb 15"
+  },
+  {
+    "index": 8,
+    "date": "2022-02-22",
+    "label": "Feb 22"
+  },
+  {
+    "index": 9,
+    "date": "2022-03-01",
+    "label": "Mar 1"
+  },
+  {
+    "index": 10,
+    "date": "2022-03-08",
+    "label": "Mar 8"
+  },
+  {
+    "index": 11,
+    "date": "2022-03-15",
+    "label": "Mar 15"
+  },
+  {
+    "index": 12,
+    "date": "2022-03-22",
+    "label": "Mar 22"
+  },
+  {
+    "index": 13,
+    "date": "2022-03-29",
+    "label": "Mar 29"
+  },
+  {
+    "index": 14,
+    "date": "2022-04-05",
+    "label": "Apr 5"
+  },
+  {
+    "index": 15,
+    "date": "2022-04-12",
+    "label": "Apr 12"
+  },
+  {
+    "index": 16,
+    "date": "2022-04-19",
+    "label": "Apr 19"
+  },
+  {
+    "index": 17,
+    "date": "2022-04-26",
+    "label": "Apr 26"
+  },
+  {
+    "index": 18,
+    "date": "2022-05-03",
+    "label": "May 3"
+  },
+  {
+    "index": 19,
+    "date": "2022-05-10",
+    "label": "May 10"
+  },
+  {
+    "index": 20,
+    "date": "2022-05-17",
+    "label": "May 17"
+  },
+  {
+    "index": 21,
+    "date": "2022-05-24",
+    "label": "May 24"
+  },
+  {
+    "index": 22,
+    "date": "2022-05-31",
+    "label": "May 31"
+  },
+  {
+    "index": 23,
+    "date": "2022-06-07",
+    "label": "Jun 7"
+  },
+  {
+    "index": 24,
+    "date": "2022-06-14",
+    "label": "Jun 14"
+  },
+  {
+    "index": 25,
+    "date": "2022-06-21",
+    "label": "Jun 21"
+  },
+  {
+    "index": 26,
+    "date": "2022-06-28",
+    "label": "Jun 28"
+  },
+  {
+    "index": 27,
+    "date": "2022-07-05",
+    "label": "Jul 5"
+  },
+  {
+    "index": 28,
+    "date": "2022-07-12",
+    "label": "Jul 12"
+  },
+  {
+    "index": 29,
+    "date": "2022-07-19",
+    "label": "Jul 19"
+  },
+  {
+    "index": 30,
+    "date": "2022-07-26",
+    "label": "Jul 26"
+  },
+  {
+    "index": 31,
+    "date": "2022-08-02",
+    "label": "Aug 2"
+  },
+  {
+    "index": 32,
+    "date": "2022-08-09",
+    "label": "Aug 9"
+  },
+  {
+    "index": 33,
+    "date": "2022-08-16",
+    "label": "Aug 16"
+  },
+  {
+    "index": 34,
+    "date": "2022-08-23",
+    "label": "Aug 23"
+  },
+  {
+    "index": 35,
+    "date": "2022-08-30",
+    "label": "Aug 30"
+  },
+  {
+    "index": 36,
+    "date": "2022-09-06",
+    "label": "Sep 6"
+  },
+  {
+    "index": 37,
+    "date": "2022-09-13",
+    "label": "Sep 13"
+  },
+  {
+    "index": 38,
+    "date": "2022-09-20",
+    "label": "Sep 20"
+  },
+  {
+    "index": 39,
+    "date": "2022-09-27",
+    "label": "Sep 27"
+  },
+  {
+    "index": 40,
+    "date": "2022-10-04",
+    "label": "Oct 4"
+  },
+  {
+    "index": 41,
+    "date": "2022-10-11",
+    "label": "Oct 11"
+  },
+  {
+    "index": 42,
+    "date": "2022-10-18",
+    "label": "Oct 18"
+  },
+  {
+    "index": 43,
+    "date": "2022-10-25",
+    "label": "Oct 25"
+  },
+  {
+    "index": 44,
+    "date": "2022-11-01",
+    "label": "Nov 1"
+  },
+  {
+    "index": 45,
+    "date": "2022-11-08",
+    "label": "Nov 8"
+  },
+  {
+    "index": 46,
+    "date": "2022-11-15",
+    "label": "Nov 15"
+  },
+  {
+    "index": 47,
+    "date": "2022-11-22",
+    "label": "Nov 22"
+  },
+  {
+    "index": 48,
+    "date": "2022-11-29",
+    "label": "Nov 29"
+  },
+  {
+    "index": 49,
+    "date": "2022-12-06",
+    "label": "Dec 6"
+  },
+  {
+    "index": 50,
+    "date": "2022-12-13",
+    "label": "Dec 13"
+  },
+  {
+    "index": 51,
+    "date": "2022-12-20",
+    "label": "Dec 20"
+  },
+  {
+    "index": 52,
+    "date": "2022-12-27",
+    "label": "Dec 27"
+  }
+]

--- a/src/assets/movement_dates.json
+++ b/src/assets/movement_dates.json
@@ -1,0 +1,262 @@
+[
+  {
+    "index": 1,
+    "date": "2022-01-07",
+    "label": "Jan 7"
+  },
+  {
+    "index": 2,
+    "date": "2022-01-14",
+    "label": "Jan 14"
+  },
+  {
+    "index": 3,
+    "date": "2022-01-21",
+    "label": "Jan 21"
+  },
+  {
+    "index": 4,
+    "date": "2022-01-28",
+    "label": "Jan 28"
+  },
+  {
+    "index": 5,
+    "date": "2022-02-04",
+    "label": "Feb 4"
+  },
+  {
+    "index": 6,
+    "date": "2022-02-11",
+    "label": "Feb 11"
+  },
+  {
+    "index": 7,
+    "date": "2022-02-18",
+    "label": "Feb 18"
+  },
+  {
+    "index": 8,
+    "date": "2022-02-25",
+    "label": "Feb 25"
+  },
+  {
+    "index": 9,
+    "date": "2022-03-04",
+    "label": "Mar 4"
+  },
+  {
+    "index": 10,
+    "date": "2022-03-11",
+    "label": "Mar 11"
+  },
+  {
+    "index": 11,
+    "date": "2022-03-18",
+    "label": "Mar 18"
+  },
+  {
+    "index": 12,
+    "date": "2022-03-25",
+    "label": "Mar 25"
+  },
+  {
+    "index": 13,
+    "date": "2022-04-01",
+    "label": "Apr 1"
+  },
+  {
+    "index": 14,
+    "date": "2022-04-08",
+    "label": "Apr 8"
+  },
+  {
+    "index": 15,
+    "date": "2022-04-15",
+    "label": "Apr 15"
+  },
+  {
+    "index": 16,
+    "date": "2022-04-22",
+    "label": "Apr 22"
+  },
+  {
+    "index": 17,
+    "date": "2022-04-29",
+    "label": "Apr 29"
+  },
+  {
+    "index": 18,
+    "date": "2022-05-06",
+    "label": "May 6"
+  },
+  {
+    "index": 19,
+    "date": "2022-05-13",
+    "label": "May 13"
+  },
+  {
+    "index": 20,
+    "date": "2022-05-20",
+    "label": "May 20"
+  },
+  {
+    "index": 21,
+    "date": "2022-05-27",
+    "label": "May 27"
+  },
+  {
+    "index": 22,
+    "date": "2022-06-03",
+    "label": "Jun 3"
+  },
+  {
+    "index": 23,
+    "date": "2022-06-10",
+    "label": "Jun 10"
+  },
+  {
+    "index": 24,
+    "date": "2022-06-17",
+    "label": "Jun 17"
+  },
+  {
+    "index": 25,
+    "date": "2022-06-24",
+    "label": "Jun 24"
+  },
+  {
+    "index": 26,
+    "date": "2022-07-01",
+    "label": "Jul 1"
+  },
+  {
+    "index": 27,
+    "date": "2022-07-08",
+    "label": "Jul 8"
+  },
+  {
+    "index": 28,
+    "date": "2022-07-15",
+    "label": "Jul 15"
+  },
+  {
+    "index": 29,
+    "date": "2022-07-22",
+    "label": "Jul 22"
+  },
+  {
+    "index": 30,
+    "date": "2022-07-29",
+    "label": "Jul 29"
+  },
+  {
+    "index": 31,
+    "date": "2022-08-05",
+    "label": "Aug 5"
+  },
+  {
+    "index": 32,
+    "date": "2022-08-12",
+    "label": "Aug 12"
+  },
+  {
+    "index": 33,
+    "date": "2022-08-19",
+    "label": "Aug 19"
+  },
+  {
+    "index": 34,
+    "date": "2022-08-26",
+    "label": "Aug 26"
+  },
+  {
+    "index": 35,
+    "date": "2022-09-02",
+    "label": "Sep 2"
+  },
+  {
+    "index": 36,
+    "date": "2022-09-09",
+    "label": "Sep 9"
+  },
+  {
+    "index": 37,
+    "date": "2022-09-16",
+    "label": "Sep 16"
+  },
+  {
+    "index": 38,
+    "date": "2022-09-23",
+    "label": "Sep 23"
+  },
+  {
+    "index": 39,
+    "date": "2022-09-30",
+    "label": "Sep 30"
+  },
+  {
+    "index": 40,
+    "date": "2022-10-07",
+    "label": "Oct 7"
+  },
+  {
+    "index": 41,
+    "date": "2022-10-14",
+    "label": "Oct 14"
+  },
+  {
+    "index": 42,
+    "date": "2022-10-21",
+    "label": "Oct 21"
+  },
+  {
+    "index": 43,
+    "date": "2022-10-28",
+    "label": "Oct 28"
+  },
+  {
+    "index": 44,
+    "date": "2022-11-04",
+    "label": "Nov 4"
+  },
+  {
+    "index": 45,
+    "date": "2022-11-11",
+    "label": "Nov 11"
+  },
+  {
+    "index": 46,
+    "date": "2022-11-18",
+    "label": "Nov 18"
+  },
+  {
+    "index": 47,
+    "date": "2022-11-25",
+    "label": "Nov 25"
+  },
+  {
+    "index": 48,
+    "date": "2022-12-02",
+    "label": "Dec 2"
+  },
+  {
+    "index": 49,
+    "date": "2022-12-09",
+    "label": "Dec 9"
+  },
+  {
+    "index": 50,
+    "date": "2022-12-16",
+    "label": "Dec 16"
+  },
+  {
+    "index": 51,
+    "date": "2022-12-23",
+    "label": "Dec 23"
+  },
+  {
+    "index": 52,
+    "date": "2022-12-31",
+    "label": "Dec 31"
+  }
+]

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -5,20 +5,8 @@ import ab_dates from '../assets/abundance_dates.json';
 import mv_dates from '../assets/movement_dates.json';
 
 
-// Displays tick marks and labels 
-const marks = [
-  { value: 1, label: 'Jan' },
-  { value: 5, label: 'Feb' },
-  { value: 9, label: 'Mar' },
-  { value: 13, label: 'Apr' },
-  { value: 18, label: 'May' },
-  { value: 22, label: 'Jun' },
-  { value: 27, label: 'Jul' },
-  { value: 32, label: 'Aug' },
-  { value: 36, label: 'Sep' },
-  { value: 40, label: 'Oct' },
-  { value: 45, label: 'Nov' },
-  { value: 49, label: 'Dec' },
+const months: Array<string> = [
+  'Jan','Feb','Mar','Apr', 'May' ,'Jun','Jul','Aug', 'Sep','Oct','Nov','Dec'
 ];
 
 // Keeps track of the props and prop type going into the component (look up interfaces in TypeScript)
@@ -28,6 +16,11 @@ interface TimelineProps {
   onChangeWeek: (val: number) => void;
 }
 
+interface markProps {
+  value: number;
+  label: string;
+}
+
 /* Creates a custom timeline slider that updates what week number of the year the user is currently on. */
 function Timeline(props: TimelineProps) {
   const { week, onChangeWeek } = props;
@@ -35,18 +28,32 @@ function Timeline(props: TimelineProps) {
   const [weekLabel, setWeekLabel] = useState<string>('');
   const [labelInit, setLabelInit] = useState<boolean>(false);
   const [myLabels, setMyLabels] = useState<Array<Array<string>>>([[],[]]);
+  const [marks, setMarks] = useState<Array<Array<markProps>>>([[],[]]);
 
   useEffect(() => {
     // initialize labels[dataset][week]
     // TODO the order of the labels needs to match the order of datasets in dataUrl.tsx/dataInfo[]
+    let datasets = [ab_dates, mv_dates]
     let local_dates: Array<Array<string>> = [[],[]];
-    ab_dates.map((info) => (
-      local_dates[0].push(info.label)
-    ))
-    mv_dates.map((info) => (
-      local_dates[1].push(info.label)
-    ))
+    for (var i =0; i < datasets.length; i += 1) {
+      datasets[i].map((info) => (
+        local_dates[i].push(info.label)
+      ))
+    }
     setMyLabels(local_dates);
+
+    // initialize which timesteps get a month marker
+    let local_marks:Array<Array<markProps>> =[[],[]]
+    for (var i =0; i < datasets.length; i += 1) {
+      for (var month of months){
+        const result = datasets[i].find(({ label }) => label.includes(month));
+        if (result !== undefined) {
+          const thisMark: markProps = {value: result.index, label: month};
+          local_marks[i].push(thisMark);
+        }
+      }
+    }
+    setMarks(local_marks);
     setLabelInit(true);
   }, []);
 
@@ -77,7 +84,7 @@ function Timeline(props: TimelineProps) {
         defaultValue={week}
         value={week}
         label={weekLabel}
-        marks={marks} // lg screen
+        marks={marks[dataset]} // lg screen
         min={1}
         max={52}
         labelAlwaysOn

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useState } from 'react';
 import { Slider } from '@mantine/core';
 import { isMobile } from '../utils/utils';
+import ab_dates from '../assets/abundance_dates.json';
+import mv_dates from '../assets/movement_dates.json';
+
 
 // Displays tick marks and labels 
 const marks = [
   { value: 1, label: 'Jan' },
-  { value: 6, label: 'Feb' },
-  { value: 10, label: 'Mar' },
-  { value: 14, label: 'Apr' },
+  { value: 5, label: 'Feb' },
+  { value: 9, label: 'Mar' },
+  { value: 13, label: 'Apr' },
   { value: 18, label: 'May' },
-  { value: 23, label: 'Jun' },
+  { value: 22, label: 'Jun' },
   { value: 27, label: 'Jul' },
   { value: 32, label: 'Aug' },
   { value: 36, label: 'Sep' },
@@ -18,36 +21,41 @@ const marks = [
   { value: 49, label: 'Dec' },
 ];
 
-const dateLabels = ['Jan 1', 'Jan 8', 'Jan 15', 'Jan 22', 'Jan 29',
-'Feb 5', 'Feb 12', 'Feb 19', 'Feb 26', 
-'Mar 3', 'Mar 10', 'Mar 17', 'Mar 24', 'Mar 31',
-'Apr 7', 'Apr 14', 'Apr 21', 'Apr 28', 
-'May 5', 'May 12', 'May 19', 'May 26',
-'Jun 2', 'Jun 9', 'Jun 16', 'Jun 23', 'Jun 30',
-'Jul 7', 'Jul 14', 'Jul 21', 'Jul 28',
-'Aug 4', 'Aug 11', 'Aug 18', 'Aug 25',
-'Sep 1', 'Sep 8', 'Sep 15', 'Sep 22', 'Sep 29',
-'Oct 6', 'Oct 13', 'Oct 20', 'Oct 27',
-'Nov 3', 'Nov 10', 'Nov 17', 'Nov 24', 
-'Dec 1', 'Dec 8', 'Dec 15', 'Dec 22'
-];
- 
-
 // Keeps track of the props and prop type going into the component (look up interfaces in TypeScript)
 interface TimelineProps {
   week: number;
+  dataset: number;
   onChangeWeek: (val: number) => void;
 }
 
 /* Creates a custom timeline slider that updates what week number of the year the user is currently on. */
 function Timeline(props: TimelineProps) {
   const { week, onChangeWeek } = props;
+  const dataset = props.dataset;
   const [weekLabel, setWeekLabel] = useState<string>('');
+  const [labelInit, setLabelInit] = useState<boolean>(false);
+  const [myLabels, setMyLabels] = useState<Array<Array<string>>>([[],[]]);
+
+  useEffect(() => {
+    // initialize labels[dataset][week]
+    // TODO the order of the labels needs to match the order of datasets in dataUrl.tsx/dataInfo[]
+    let local_dates: Array<Array<string>> = [[],[]];
+    ab_dates.map((info) => (
+      local_dates[0].push(info.label)
+    ))
+    mv_dates.map((info) => (
+      local_dates[1].push(info.label)
+    ))
+    setMyLabels(local_dates);
+    setLabelInit(true);
+  }, []);
 
   useEffect(() => {
     // update the label WHEN the check for overlay is complete
-    setWeekLabel(dateLabels[week-1]);
-  }, [week]);
+    if (labelInit) {
+      setWeekLabel(myLabels[dataset][week-1]);
+    }
+  }, [week, props.dataset]);
 
   return (
     <div className="Timeline">
@@ -59,9 +67,9 @@ function Timeline(props: TimelineProps) {
         min={1}
         max={52}
         labelAlwaysOn
-        size='sm'
+        size='sm' // sm screen
         step={1}
-        thumbSize={12}
+        thumbSize={12}  // sm screen
         onChange={(v) => { onChangeWeek(v)}}
       />
       : 
@@ -69,12 +77,12 @@ function Timeline(props: TimelineProps) {
         defaultValue={week}
         value={week}
         label={weekLabel}
-        marks={marks}
+        marks={marks} // lg screen
         min={1}
         max={52}
         labelAlwaysOn
         step={1}
-        thumbSize={20}
+        thumbSize={20} // lg screen
         onChange={(v) => onChangeWeek(v)}
       />}
     </div>

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -292,7 +292,7 @@ const HomePage = () => {
       {/* Calls the custom legend component with the data type and species type as parameters. */}
       <Legend dataTypeIndex={dataIndex} speciesIndex={speciesIndex} />
       {/* Calls the custom timeline component with the current week onChange function as parameters */}
-      <Timeline week={week} onChangeWeek={checkImageAndUpdate} />
+      <Timeline week={week} dataset={dataIndex} onChangeWeek={checkImageAndUpdate} />
     </div>
   );
 }


### PR DESCRIPTION
so they properly match to data shown.
The correct dates for the datasets are in abundance_dates.json and movement_dates.json from the BirdFlow git.  The exact git location is part of the README.  The timeline now loads in both sets of dates at the beginning and then sets the appropriate label for the currently shown dataset and week.