### PR TITLE
feat: overhaul HPAI Outbreak display with updated symbology and legend

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -4,7 +4,7 @@ import taxa from "../assets/taxa.json";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../store/store";
 import { dataInfo } from "../hooks/dataUrl";
-import { toggleOutbreaks } from "../store/slices/mapSlice";
+import { toggleRecentOutbreaks, toggleHistoricOutbreaks } from "../store/slices/mapSlice";
 import { Tooltip } from "@mantine/core";
 
 type ControlBarProps = {
@@ -28,7 +28,8 @@ export default function ControlBar({
 
   const selectedDataType = useSelector((state: RootState) => state.species.dataIndex);
   const selectedSpecies = useSelector((state: RootState) => state.species.speciesIndex);
-  const showOutbreaks = useSelector((state: RootState) => state.map.showOutbreaks);
+  const showRecentOutbreaks = useSelector((state: RootState) => state.map.showRecentOutbreaks);
+  const showHistoricOutbreaks = useSelector((state: RootState) => state.map.showHistoricOutbreaks);
   const dataTypes = dataInfo.map((dt, idx) => ({ value: idx, label: dt.label }));
 
   // Close dropdowns on outside click
@@ -78,18 +79,37 @@ export default function ControlBar({
               <div className="mb-2 text-xs text-blue-700 font-bold uppercase tracking-wide">Outbreaks</div>
               <div className="flex items-center justify-between bg-blue-50/50 p-2 rounded-lg">
                 <label htmlFor="outbreak-toggle" className="font-medium text-blue-800 text-sm">
-                  Show HPAI Outbreaks
+                  Recent
                 </label>
                 <button
                   id="outbreak-toggle"
-                  onClick={() => dispatch(toggleOutbreaks())}
+                  onClick={() => dispatch(toggleRecentOutbreaks())}
                   className={`relative inline-flex items-center h-6 rounded-full w-11 transition-colors ${
-                    showOutbreaks ? 'bg-blue-500' : 'bg-gray-300'
+                    showRecentOutbreaks ? 'bg-blue-500' : 'bg-gray-300'
                   }`}
                 >
                   <span
                     className={`inline-block w-4 h-4 transform bg-white rounded-full transition-transform ${
-                      showOutbreaks ? 'translate-x-6' : 'translate-x-1'
+                      showRecentOutbreaks ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between bg-blue-50/50 p-2 rounded-lg">
+                <label htmlFor="outbreak-toggle" className="font-medium text-blue-800 text-sm">
+                  Historic
+                </label>
+                <button
+                  id="outbreak-toggle"
+                  onClick={() => dispatch(toggleHistoricOutbreaks())}
+                  className={`relative inline-flex items-center h-6 rounded-full w-11 transition-colors ${
+                    showHistoricOutbreaks ? 'bg-blue-500' : 'bg-gray-300'
+                  }`}
+                >
+                  <span
+                    className={`inline-block w-4 h-4 transform bg-white rounded-full transition-transform ${
+                      showHistoricOutbreaks ? 'translate-x-6' : 'translate-x-1'
                     }`}
                   />
                 </button>

--- a/src/components/DataLegend.tsx
+++ b/src/components/DataLegend.tsx
@@ -30,7 +30,7 @@ import { RootState } from '../store/store';
 /*
 - This is the Birds/km^2 (or Birds/km/week) Legend on the bottom left of the screen.
 */
-function Legend() {
+function DataLegend() {
   const dataIndex = useSelector((state: RootState) => state.species.dataIndex);
   const speciesIndex = useSelector((state: RootState) => state.species.speciesIndex);
   const currentWeek = useSelector((state: RootState) => state.timeline.week);
@@ -94,9 +94,12 @@ function Legend() {
     />
   );
 
+
+  const dataLabel = dataInfo[dataIndex].label;
+
   return (
     <div
-      className="Legend"
+      className="DataLegend"
       style={{
         background: 'rgba(255, 255, 255, 0.6)',
         borderRadius: 10,
@@ -104,6 +107,9 @@ function Legend() {
         maxWidth: isMobile() ? '60px' : '120px',
       }}
     >
+      <div style={{ fontWeight: 'bold', textAlign: 'center', marginBottom: 6, fontSize: 12}}>
+        {dataLabel} Scale
+      </div>
       {isMobile() ? (
         <>
           <div style={{ textAlign: 'center', fontSize: 12 }}>{highLabel}</div>
@@ -134,4 +140,4 @@ function Legend() {
   );
 }
 
-export default Legend;
+export default DataLegend;

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,14 +1,12 @@
-import { ImageOverlay, MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
-import { OutbreakMarkers } from "./OutbreakPoints";
+import { ImageOverlay, MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
+import { HistoricOutbreakMarkers, RecentOutbreakMarkers } from "./OutbreakPoints";
 import { GeoSearchControl, OpenStreetMapProvider } from "leaflet-geosearch";
 import "leaflet-geosearch/dist/geosearch.css";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../store/store";
 import { clearFlowResults, clearOverlayUrl } from '../store/slices/mapSlice';
-import { IconClick, IconSearch } from "@tabler/icons-react";
-import { Tooltip } from '@mantine/core';
 
 const imageBounds = [
   [9.622994, -170.291626],
@@ -127,7 +125,8 @@ export default function MapView({ week, dataIndex, onLocationSelect, useSearchMo
   const dispatch = useDispatch();
 
   const overlayUrl = useSelector((state: RootState) => state.map.overlayUrl);
-  const showOutbreaks = useSelector((state: RootState) => state.map.showOutbreaks); // Get the toggle state
+  const showRecentOutbreaks = useSelector((state: RootState) => state.map.showRecentOutbreaks);
+  const showHistoricOutbreaks = useSelector((state: RootState) => state.map.showHistoricOutbreaks);
   const [markerPosition, setMarkerPosition] = useState<{ lat: number, lng: number } | null>(null);
 
   const position = { lat: 45, lng: -95 };
@@ -162,33 +161,6 @@ export default function MapView({ week, dataIndex, onLocationSelect, useSearchMo
 
   return (
     <div style={{ position: "relative" }}>
-      {/* Toggle Button moved to Home.tsx */}
-      {/*
-      {isInflowOutflowView && (
-        <Tooltip label="Flow start location" position="top" withArrow offset={8}>
-          <button
-            className="absolute top-4 left-12 z-[1200] flex items-center gap-2
-              px-2 py-2 sm:px-4 sm:py-2
-              rounded-xl border-2 border-blue-400 bg-white/90 text-blue-500 font-semibold shadow-md
-              hover:bg-blue-50 hover:border-blue-500 transition
-              text-base sm:text-base"
-            onClick={toggleMode}
-            type="button"
-          >
-            {useSearchMode ? (
-              <>
-                <IconClick size={20} className="text-blue-500 sm:w-5 sm:h-5 w-5 h-5" />
-                <span className="hidden sm:inline">Switch to Click Mode</span>
-              </>
-            ) : (
-              <>
-                <IconSearch size={20} className="text-blue-500 sm:w-5 sm:h-5 w-5 h-5" />
-                <span className="hidden sm:inline">Switch to Search Mode</span>
-              </>
-            )}
-          </button>
-        </Tooltip>
-      )} */}
     <MapContainer
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -235,9 +207,8 @@ export default function MapView({ week, dataIndex, onLocationSelect, useSearchMo
           </Popup>
         </Marker>
       )}
-
-      {/* This line now correctly hides/shows the markers */}
-      {showOutbreaks && OutbreakMarkers(week)}
+      {showRecentOutbreaks && RecentOutbreakMarkers(week)}
+      {showHistoricOutbreaks && HistoricOutbreakMarkers(week)}
     </MapContainer>
     </div>
   );

--- a/src/components/OutbreakPoints.tsx
+++ b/src/components/OutbreakPoints.tsx
@@ -1,10 +1,9 @@
 import { Marker, Popup } from 'react-leaflet';
-import { Icon } from 'leaflet';
+import L from 'leaflet';
 import outbreaks from '../assets/outbreaks.json';
-import iconOne from '../assets/redLocationIcon.png';
-import iconTwo from '../assets/orangeLocationIcon.png';
-import iconThree from '../assets/iconPaleBlue.png';
-import {monthDayToWeek, dateToWeek} from '../utils/utils'
+import { monthDayToWeek, isMobile } from '../utils/utils'
+import { useSelector } from 'react-redux';
+import { RootState } from '../store/store';
 
 // lat, long position in degrees
 type GeoLocation = [number, number]
@@ -15,121 +14,184 @@ type outMarker = {
     yearsAgo: number;
     week: number;
     label: string;
-}
-
-// This is the red location marker icon that is displayed on the map
-function outbreakIcon(icon_path: string) {
-    return new Icon({
-        iconUrl: icon_path,
-        iconSize: [22,35], // size of the icon
-        iconAnchor: [18, 35], // the tip of the icon points to the middle bottom of the png
-        popupAnchor: [8, -30] // point from which the popup should open relative to the iconAnchor
-    })
+    opacity?: number;
 }
 
 const outbreakMarkers: outMarker[]=[];
-const NUM_WEEKS = 2; // display outbreaks that occurred this_date +/- NUM_WEEKS
+const NUM_OUTBREAK_WEEKS = 3;
 const thisYear = new Date().getFullYear();
-const thisWeek = dateToWeek(new Date());
-const markerIcons: (typeof Icon)[] = [
-    outbreakIcon(iconOne),
-    outbreakIcon(iconTwo),
-    outbreakIcon(iconThree),
-    outbreakIcon(iconThree),
-]
 
-/* This method goes through outbreaks.json, extract data from these entries and add it to the outbreakMarkers[] array to be processed by selectedOutbreaks() method */
-export function loadOutbreaks() {
-    if (outbreakMarkers.length > 0) {
-        // only run this once
-        return;
-    }
-
-    // convert outbreak data into markers by translating the State/County pairs into lat/log 
-    for (var outbreak of outbreaks) {
-        const outbreak_year = Number(outbreak.Confirmed.split('-')[0]);
-        let marker:outMarker = {
-            year: outbreak_year,
-            yearsAgo: thisYear - outbreak_year,
-            week: monthDayToWeek(Number(outbreak.Confirmed.split('-')[1]), Number(outbreak.Confirmed.split('-')[2])),
-            geoLoc: [outbreak.GeoLoc[0],outbreak.GeoLoc[1]],
-            label: outbreak.Confirmed+': '+outbreak.Production+' ('+outbreak.NumInfected+')',
-        }
-        if (marker.yearsAgo <= 1 ) {   
-            outbreakMarkers.push(marker);
-        }
-    }
-}
-
-
-/* The way I understand this, this method returns the list of outbreaks to be rendered as OutbreakMarkers, in the current week. As for how the list is calculated/returned, I don't really know since Pam did it */
-function selectedOutbreaks(this_week: number):outMarker[] {
-    // show only outbreaks in the last year.  
-    const markers: outMarker[]=[];
-
-    for (var info of outbreakMarkers) {
-        if ((info.yearsAgo === 0)  && (Math.abs(info.week-this_week) < NUM_WEEKS)) {
-            // this year near the display date
-            markers.push(info);
-        }
-        else if ((info.yearsAgo === 1)  && (info.week > thisWeek) && (Math.abs(info.week-this_week) < NUM_WEEKS)) {
-            // last year, after today and near displayed day, 
-            markers.push(info);
-        } 
-    }
-    return markers;
-}
-
+const RECENT_COLOR = 'red'
+const HISTORIC_COLOR = '#57B9FF'
 
 /**
- * Renders outbreak markers for a given week (this is the location marker that changes when you move the slider bar).
+ * Creates a circle-shaped Leaflet divIcon with the given color and opacity.
  *
- * @param week - The week number to filter and display outbreak markers for.
- * @returns An array of Marker components representing outbreaks for the specified week.
- *
- * Each marker uses an icon based on how many years ago the outbreak occurred,
- * and displays a popup with a label describing the outbreak.
+ * @param color - Any valid CSS color (e.g. 'black', '#ff0000', 'rgba(0,0,0,0.5)')
+ * @param opacity - A value from 0 to 1 for icon transparency
+ * @param size - Optional circle size in pixels (default: 14)
+ * @returns A Leaflet DivIcon
  */
-export function OutbreakMarkers(week: number) {
-    const currentMarkers = selectedOutbreaks(week);
+export function circleIcon(color: string, opacity: number, size: number = 14) {
+    const style = `
+        width: ${size}px;
+        height: ${size}px;
+        background-color: ${color};
+        opacity: ${opacity};
+        border-radius: 50%;
+    `;
+
+    return L.divIcon({
+        html: `<div style="${style}"></div>`,
+        iconSize: [size, size],
+        className: '' // remove default marker styling
+    });
+}
+
+
+export function loadOutbreaks() {
+    if (outbreakMarkers.length > 0) return;
+
+    outbreaks.forEach(outbreak => {
+        const [yearStr, monthStr, dayStr] = outbreak.Confirmed.split('-');
+        const year = Number(yearStr);
+        const month = Number(monthStr);
+        const day = Number(dayStr);
+
+        outbreakMarkers.push({
+            year,
+            yearsAgo: thisYear - year,
+            week: monthDayToWeek(month, day),
+            geoLoc: [outbreak.GeoLoc[0], outbreak.GeoLoc[1]],
+            label: `${outbreak.Confirmed}: ${outbreak.Production} (${outbreak.NumInfected})`,
+        });
+    });
+}
+
+
+function selectedOutbreaks(week: number, type: 'recent' | 'historic') : outMarker[] {
+    const cutoffWeek = week - NUM_OUTBREAK_WEEKS;
+    return outbreakMarkers
+        .filter(marker => {
+            if (type === 'recent') return marker.yearsAgo === 0;
+            if (type === 'historic') return marker.yearsAgo > 0;
+            return false;
+        })
+        .map(marker => {
+            let opacity = 0.4; // default for Historic
+
+            if (marker.yearsAgo === 0) {
+                // Marker is from current year and within NUM_OUTBREAK_WEEKS weeks before the selected week
+                if (marker.week >= cutoffWeek && marker.week <= week) {
+                    opacity = 1.0;
+                // Marker is from current year but more than NUM_OUTBREAK_WEEKS weeks before the selected week
+                } else if (marker.week < cutoffWeek) {
+                    opacity = 0.7;
+                // Marker is from current year but after the selected week
+                } else {
+                    opacity = 0.5;
+                }
+            }
+
+            return {
+                ...marker,
+                opacity
+            };
+        });
+}
+
+
+export function RecentOutbreakMarkers(week: number) {
+    const currentMarkers = selectedOutbreaks(week, 'recent');
     return (
-        currentMarkers.map((info, i) => (
+        currentMarkers.map((marker, i) => (
             // @ts-ignore
-            <Marker icon={markerIcons[info.yearsAgo]}
-                position={info.geoLoc}
+            <Marker icon={circleIcon(RECENT_COLOR, marker.opacity)}
+                position={marker.geoLoc}
                 key={i}
             >
-                <Popup>
-                    {info.label}
-                </Popup>
+                <Popup> {marker.label} </Popup>
             </Marker>
         ))
     ); 
 }
 
 
-/**
- * Renders a legend for outbreak points, displaying icons and labels for the current year and the previous year.
- *
- * @component
- * @returns {JSX.Element} The outbreak legend component with icons and corresponding year labels.
- *
- * @example
- * <OutbreakLegend />
- *
- * @remarks
- * - Expects `iconOne`, `iconTwo`, and `thisYear` to be defined in the parent scope.
- * - Each legend entry consists of an icon and a bold label indicating the year.
- */
-export const OutbreakLegend = () => (
-    <div>
-        <div style={{display:"flex"}}>
-            <img src={iconOne} id="this_year" style={{ width: '20px', height: '30px' }} />    
-            <label style={{fontWeight:"bold", margin:'5px'}}>{thisYear}</label>
+export function HistoricOutbreakMarkers(week: number) {
+    const currentMarkers = selectedOutbreaks(week, 'historic');
+    return (
+        currentMarkers.map((marker, i) => (
+            // @ts-ignore
+            <Marker icon={circleIcon(HISTORIC_COLOR, marker.opacity)}
+                position={marker.geoLoc}
+                key={i}
+            >
+                <Popup> {marker.label} </Popup>
+            </Marker>
+        ))
+    ); 
+}
+
+
+export function OutbreakLegend() {
+  const showRecentOutbreaks = useSelector((state: RootState) => state.map.showRecentOutbreaks);
+  const showHistoricOutbreaks = useSelector((state: RootState) => state.map.showHistoricOutbreaks);
+
+  if (!showRecentOutbreaks && !showHistoricOutbreaks) {
+    return null;
+  }
+
+  function LegendIcon({ color, opacity, size = 14 }: { color: string; opacity: number; size?: number }) {
+    return (
+        <div
+        style={{
+            width: size,
+            height: size,
+            backgroundColor: color,
+            opacity,
+            borderRadius: '50%',
+            marginRight: 8,
+        }}
+        />
+    );
+    }
+
+  return (
+    <div
+      className="OutbreakLegend"
+      style={{
+        background: 'rgba(255, 255, 255, 0.6)',
+        borderRadius: 10,
+        padding: '6px 10px',
+        fontSize: 12,
+        maxWidth: '220px',
+        marginBottom: 10,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+      }}
+    >
+      <div style={{ fontWeight: 'bold', textAlign: 'center' }}>Outbreaks</div>
+
+      {showRecentOutbreaks && (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <LegendIcon color={RECENT_COLOR} opacity={1.0} /> <span>Last 3 weeks</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <LegendIcon color={RECENT_COLOR} opacity={0.75} /> <span>&gt;3 weeks before</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <LegendIcon color={RECENT_COLOR} opacity={0.5} /> <span>After selected week</span>
+          </div>
+        </>
+      )}
+
+      {showHistoricOutbreaks && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <LegendIcon color={HISTORIC_COLOR} opacity={0.5} /> <span>Historic (past years)</span>
         </div>
-        <div style={{display:"flex"}}>
-            <img src={iconTwo} id="last_year" style={{ width: '20px', height: '30px' }} />    
-            <label style={{fontWeight:"bold", margin:'5px'}}>{thisYear-1}</label>
-        </div>
+      )}
     </div>
-);
+  );
+}

--- a/src/store/slices/mapSlice.tsx
+++ b/src/store/slices/mapSlice.tsx
@@ -15,14 +15,16 @@ interface MapState {
   overlayUrl: string;
   flowResults: FlowResult[]; // stores all API Flow results
   flowGeoTiffUrl: string;
-  showOutbreaks: boolean;
+  showRecentOutbreaks: boolean;
+  showHistoricOutbreaks: boolean;
 }
 
 const initialState: MapState = {
   overlayUrl: "",
   flowResults: [],
   flowGeoTiffUrl: "",
-  showOutbreaks: true,
+  showRecentOutbreaks: true,
+  showHistoricOutbreaks: false,
 };
 
 const mapSlice = createSlice({
@@ -48,8 +50,11 @@ const mapSlice = createSlice({
       const match = state.flowResults.find((r) => r.week === action.payload);
       state.overlayUrl = match ? match.url : "";
     },
-    toggleOutbreaks(state) {
-      state.showOutbreaks = !state.showOutbreaks;
+    toggleRecentOutbreaks(state) {
+      state.showRecentOutbreaks = !state.showRecentOutbreaks;
+    },
+    toggleHistoricOutbreaks(state) {
+      state.showHistoricOutbreaks = !state.showHistoricOutbreaks;
     },
   },
 });
@@ -60,7 +65,8 @@ export const {
   setFlowResults,
   clearFlowResults,
   updateOverlayByWeek,
-  toggleOutbreaks,
+  toggleRecentOutbreaks,
+  toggleHistoricOutbreaks,
 } = mapSlice.actions;
 
 export default mapSlice.reducer;

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -23,12 +23,19 @@
         right: 5px;
     }
 
-    	
-    .Legend {
+    .DataLegend {
         position: absolute;
-        bottom: 150px;
+        bottom: 160px;
         left: 10px;
         z-index: 10;
+        white-space: pre-line;
+    }
+
+    .OutbreakLegend {
+        position: absolute;
+        bottom: 430px;
+        left: 10px;
+        z-index: 20;
         white-space: pre-line;
     }
 

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Combobox, ComboboxStore, useCombobox, Tooltip } from '@mantine/core';
+import { Combobox, ComboboxStore, useCombobox } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import L from 'leaflet';
 import AboutButtons from '../components/AboutButtons';
 import ControlBar from '../components/ControlBar';
 import InflowOutflowCalculateButton from '../components/InflowOutflowCalculateButton';
 import FlowDownloadButton from '../components/FlowDownloadButton';
-import Legend from '../components/Legend';
+import DataLegend from '../components/DataLegend';
 import MapOverlayPanel from '../components/MapOverlayPanel';
 import MapView from '../components/MapView';
 import Timeline from '../components/Timeline/Timeline';
@@ -29,7 +29,6 @@ import {
   updateOverlayByWeek,
   clearOverlayUrl,
 } from '../store/slices/mapSlice';
-import { IconClick, IconSearch } from '@tabler/icons-react';
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-geosearch/dist/geosearch.css';
@@ -77,7 +76,6 @@ const HomePage = () => {
   const speciesIndex = useSelector((state: RootState) => state.species.speciesIndex);
   const dataIndex = useSelector((state: RootState) => state.species.dataIndex);
   const flowResults = useSelector((state: RootState) => state.map.flowResults);
-  const showOutbreaks = useSelector((state: RootState) => state.map.showOutbreaks);
 
   // const [week, setWeek] = useState(MIN_WEEK);
   const week = useSelector((state: RootState) => state.timeline.week);
@@ -221,7 +219,7 @@ const HomePage = () => {
   // Shows the Legend component if:
 	// - dataIndex < 2 (e.g., for abundance or movement), or
 	// - flowResults is a non-empty array (e.g., for inflow or outflow when results exist).
-  const shouldShowLegend = dataIndex < 2 || (Array.isArray(flowResults) && flowResults.length > 0);
+  const shouldShowDataLegend = dataIndex < 2 || (Array.isArray(flowResults) && flowResults.length > 0);
 
 // Here is where you list the components and elements that you want rendered. 
   return (
@@ -282,18 +280,9 @@ const HomePage = () => {
           week={week}
           dataIndex={dataIndex}
           onLocationSelect={handleLocationSelect}
-          useSearchMode={useSearchMode} // <-- add this
+          useSearchMode={useSearchMode}
         />
       </div>
-      {showOutbreaks && (
-        <div className="widgets">
-          <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
-            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
-              <OutbreakLegend />
-            </div>
-          </div>
-        </div>
-      )}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-3 items-end">
         <AboutButtons />
         <ControlBar
@@ -304,7 +293,8 @@ const HomePage = () => {
         />
       </div>
 
-      {shouldShowLegend && <Legend />}
+      {shouldShowDataLegend && <DataLegend />}
+      <OutbreakLegend />
 
       <Timeline
         onChangeWeek={onChangeWeek}


### PR DESCRIPTION
- Reworked outbreak rendering logic to distinguish "Recent" (current year) and "Historic" (past years) outbreaks.
- Introduced variable opacity for **current**-year outbreaks: 
  - `Last 3 weeks before selected week` → opacity 1.0 
  - `>3 weeks before` → opacity 0.75 
  - `After selected week` → opacity 0.5
- **Historic** outbreaks now displayed with consistent blue icon at 50% opacity.
- Updated `OutbreakLegend` component: • Renders only when corresponding layer is active 
- Uses custom circular icons to indicate legend categories 
- Styled to align visually above DataLegend on the map