### PR TITLE
refactor: simplify MapView with unified marker logic and search reset

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,89 +1,62 @@
 import "leaflet/dist/leaflet.css";
-import { ImageOverlay, MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
-import { HistoricOutbreakMarkers, RecentOutbreakMarkers } from "./OutbreakPoints";
-import { GeoSearchControl, OpenStreetMapProvider } from "leaflet-geosearch";
 import "leaflet-geosearch/dist/geosearch.css";
+import { MapContainer, TileLayer, Marker, Popup, ImageOverlay, useMap } from "react-leaflet";
+import { GeoSearchControl, OpenStreetMapProvider } from "leaflet-geosearch";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { RootState } from "../store/store";
-import { clearFlowResults, clearOverlayUrl } from '../store/slices/mapSlice';
+import { HistoricOutbreakMarkers, RecentOutbreakMarkers } from "./OutbreakPoints";
+
 
 const imageBounds = [
   [9.622994, -170.291626],
   [79.98956, -49.783429],
 ];
 
-interface MapViewProps {
-  week: number;
-  dataIndex: number;
-  onLocationSelect: (latLonString: string | null) => void;
-  useSearchMode: boolean; // <-- add this
-}
 
-// @ts-ignore
-const searchControl = new GeoSearchControl({
-  provider: new OpenStreetMapProvider(),
-  style: 'button',
-  showPopup: true,
-  retainZoomLevel: true,
-  notFoundMessage: 'Sorry, that address could not be found.',
-});
-
-function MapClickHandler({ onLocationSelect, setMarkerPosition }: any) {
+function MapClickHandler({ setMarker }: { setMarker: (lat: number, lng: number, label: string) => void }) {
   const map = useMap();
 
   useEffect(() => {
     const handleClick = (e: L.LeafletMouseEvent) => {
       const { lat, lng } = e.latlng;
-      const latLon = `${lat.toFixed(5)},${lng.toFixed(5)}`;
-      console.log('Clicked location:', latLon);
-      onLocationSelect(latLon);
-      setMarkerPosition({ lat, lng });
+      setMarker(lat, lng, "Selected Location:");
     };
 
-    map.on('click', handleClick);
-    return () => {
-      map.off('click', handleClick);
-    };
-  }, [map, onLocationSelect]);
+    map.on("click", handleClick);
+    return () => map.off("click", handleClick);
+  }, [map, setMarker]);
 
   return null;
 }
 
-function SearchField({ onLocationSelect, setMarkerPosition }: any) {
+function SearchHandler({ setMarker }: { setMarker: (lat: number, lng: number, label: string) => void }) {
   const map = useMap();
-  const [hasSearchMarker, setHasSearchMarker] = useState(false);
 
   useEffect(() => {
+    // @ts-ignore
+    const searchControl = new GeoSearchControl({
+      provider: new OpenStreetMapProvider(),
+      style: "button",
+      showMarker: false,
+      retainZoomLevel: true,
+      notFoundMessage: "Sorry, that address could not be found.",
+    });
+
     map.addControl(searchControl);
 
     const handleSearch = (result: any) => {
-      const latLon = `${result.location.y.toFixed(5)},${result.location.x.toFixed(5)}`;
-      console.log('Search selected location:', latLon);
-      onLocationSelect(latLon);
-      setMarkerPosition(null);
-      setHasSearchMarker(true);
+      const { x, y, label } = result.location;
+      setMarker(y, x, label); // y = lat, x = lng
     };
 
-    map.on('geosearch/showlocation', handleSearch);
-
-    // Poll for changes in searchControl.markers
-    const interval = setInterval(() => {
-      const currentMarkers = searchControl.markers.getLayers().length;
-
-      if (hasSearchMarker && currentMarkers === 0) {
-        console.log("Search marker removed → clearing location");
-        onLocationSelect(null);
-        setHasSearchMarker(false);
-      }
-    }, 300);
+    map.on("geosearch/showlocation", handleSearch);
 
     return () => {
       map.removeControl(searchControl);
-      map.off('geosearch/showlocation', handleSearch);
-      clearInterval(interval);
+      map.off("geosearch/showlocation", handleSearch);
     };
-  }, [map, onLocationSelect, hasSearchMarker]);
+  }, [map, setMarker]);
 
   return null;
 }
@@ -94,7 +67,6 @@ function SearchField({ onLocationSelect, setMarkerPosition }: any) {
  *
  * @param week - The current week to display outbreak markers for.
  * @param dataIndex - Index indicating which dataset is currently selected; controls search field visibility.
- * @param onLocationSelect - Callback function that receives a selected or clicked lat/lon string.
  * @returns JSX.Element representing the map view with overlays and controls.
  *
  * Features:
@@ -106,7 +78,7 @@ function SearchField({ onLocationSelect, setMarkerPosition }: any) {
  *
  * Subcomponents:
  * - MapClickHandler: Uses `useMap()` to attach a click listener to the map and return lat/lon.
- * - SearchField: Uses `leaflet-geosearch` to allow address-based location search with marker and callback.
+ * - SearchHandler: Uses `leaflet-geosearch` to allow address-based location search with marker and callback.
  *
  * Dependencies:
  * - Uses `react-redux`'s `useSelector` to access overlay URL from Redux state.
@@ -115,101 +87,74 @@ function SearchField({ onLocationSelect, setMarkerPosition }: any) {
  */
 
 /*
-- SearchField component: A geolocation search bar powered by leaflet-geosearch (https://smeijer.github.io/leaflet-geosearch/)
+- SearchHandler component: A geolocation search bar powered by leaflet-geosearch (https://smeijer.github.io/leaflet-geosearch/)
 - MapClickHandler component: Listens for user clicks on the map and extracts lat/lon for callbacks
 - TileLayer component: Provides the base map (e.g. OSM tiles)
 - ImageOverlay component: Displays a heatmap-style overlay image based on the selected week
-- OutbreakMarkers function: Renders disease outbreak markers dynamically for the selected week
+- RecentOutbreakMarkers / HistoricOutbreakMarkers functions: Renders disease outbreak markers dynamically for the selected week
 */
-export default function MapView({ week, dataIndex, onLocationSelect, useSearchMode }: MapViewProps): JSX.Element {
-  const dispatch = useDispatch();
+export default function MapView({ onLocationSelect }: {onLocationSelect: (latLonString: string | null) => void} ): JSX.Element {
+  const dataIndex = useSelector((state: RootState) => state.species.dataIndex);
+  const week = useSelector((state: RootState) => state.timeline.week);
 
   const overlayUrl = useSelector((state: RootState) => state.map.overlayUrl);
   const showRecentOutbreaks = useSelector((state: RootState) => state.map.showRecentOutbreaks);
   const showHistoricOutbreaks = useSelector((state: RootState) => state.map.showHistoricOutbreaks);
-  const [markerPosition, setMarkerPosition] = useState<{ lat: number, lng: number } | null>(null);
 
-  const position = { lat: 45, lng: -95 };
-
+  const [markerInfo, setmarkerInfo] = useState<{ lat: number; lng: number; label: string } | null>(null);
   const isInflowOutflowView = dataIndex >= 2;
 
-  const toggleMode = () => {
-    // Clear any existing marker on the map
-    setMarkerPosition(null);
-
-    // Clear markers and search results from the search control
-    searchControl.markers.clearLayers();
-    searchControl.clearResults();
-
-    // Reset selected location
-    onLocationSelect(null);
-
-    // Clear previously fetched flow results and overlay image
-    dispatch(clearFlowResults());
-    dispatch(clearOverlayUrl());
+  const setMarker = (lat: number, lng: number, label: string) => {
+    const latLon = `${lat.toFixed(5)},${lng.toFixed(5)}`;
+    setmarkerInfo({ lat, lng, label });
+    onLocationSelect(latLon);
   };
 
-  // clear the marker and search result when isInflowOutflowView becomes false
   useEffect(() => {
-  if (!isInflowOutflowView) {
-    setMarkerPosition(null);
-    searchControl.markers.clearLayers();
-    searchControl.clearResults()
-    onLocationSelect(null);
-  }
-}, [isInflowOutflowView]);
+    if (!isInflowOutflowView) {
+      setmarkerInfo(null);
+      onLocationSelect(null);
+    }
+  }, [isInflowOutflowView]);
 
   return (
     <div style={{ position: "relative" }}>
-    <MapContainer
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      <MapContainer
       // @ts-ignore
-      center={position}
-      zoom={3.5}
-      style={{ height: '100vh', width: '100%' }}
-      className="Map"
-      keyboard={false}
-      maxBounds={imageBounds}
-    >
-      {isInflowOutflowView && (
-        <>
-          <SearchField
-            onLocationSelect={onLocationSelect}
-            setMarkerPosition={setMarkerPosition}
-          />
-          <MapClickHandler
-            onLocationSelect={onLocationSelect}
-            setMarkerPosition={setMarkerPosition}
-          />
-        </>
-      )}
+        center={{ lat: 45, lng: -95 }}
+        zoom={3.5}
+        style={{ height: "100vh", width: "100%" }}
+        className="Map"
+        keyboard={false}
+        maxBounds={imageBounds}
+      >
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          // @ts-ignore
+          attribution='Abundance data © <a target="_blank" href="https://ebird.org/science/status-and-trends">eBird</a> | <a target="_blank" href="https://birdflow-science.github.io/">BirdFlow</a>'
+        />
+        {/* @ts-ignore */}
+        <ImageOverlay url={overlayUrl} bounds={imageBounds} opacity={0.7} />
 
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        attribution='Abundance data provided by <a target="_blank" href="https://ebird.org/science/status-and-trends ">Cornell Lab of Ornithology - eBird</a> | <a target="_blank" href="https://birdflow-science.github.io/"> BirdFlow </a>'
-      />
+        {isInflowOutflowView && (
+          <>
+            <SearchHandler setMarker={setMarker} />
+            <MapClickHandler setMarker={setMarker} />
+          </>
+        )}
 
-      <ImageOverlay
-        url={overlayUrl}
-        bounds={imageBounds}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        opacity={0.7}
-      />
+        {markerInfo && (
+          <Marker position={[markerInfo.lat, markerInfo.lng]}>
+            <Popup>
+              {markerInfo.label}<br />
+              {markerInfo.lat.toFixed(2)}, {markerInfo.lng.toFixed(2)}
+            </Popup>
+          </Marker>
+        )}
 
-      {markerPosition && (
-        <Marker position={[markerPosition.lat, markerPosition.lng]}>
-          <Popup>
-            Selected Location:<br />
-            {markerPosition.lat.toFixed(5)}, {markerPosition.lng.toFixed(5)}
-          </Popup>
-        </Marker>
-      )}
-      {showRecentOutbreaks && RecentOutbreakMarkers(week)}
-      {showHistoricOutbreaks && HistoricOutbreakMarkers(week)}
-    </MapContainer>
+        {showRecentOutbreaks && RecentOutbreakMarkers(week)}
+        {showHistoricOutbreaks && HistoricOutbreakMarkers(week)}
+      </MapContainer>
     </div>
   );
 }

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -96,8 +96,6 @@ const HomePage = () => {
     dispatch(clearOverlayUrl());
   };
 
-  const toggleMode = () => setUseSearchMode((prev) => !prev);
-
   function handleWindowSizeChange() {
     if (window.innerWidth <  MIN_REG_WINDOW_WIDTH) {
       // small window
@@ -276,12 +274,7 @@ const HomePage = () => {
       </div>
 
       <div className="relative w-full h-[100vh]">
-        <MapView
-          week={week}
-          dataIndex={dataIndex}
-          onLocationSelect={handleLocationSelect}
-          useSearchMode={useSearchMode}
-        />
+        <MapView onLocationSelect={handleLocationSelect} />
       </div>
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-3 items-end">
         <AboutButtons />


### PR DESCRIPTION
### Summary

This PR simplifies and refactors the `MapView` component to improve usability and maintainability. It unifies the marker logic for both map click and address search interactions, ensuring consistent behavior and reducing code duplication.

### Changes

- Unified marker creation logic via a single `setMarker` handler.
- Simplified `MapClickHandler` and `SearchHandler` subcomponents.
- Automatically clears the search input after a successful address lookup.
- Ensured only one marker appears at any time (replaces old one on new selection).
- Removed unused props (`useSearchMode`) and redundant state.
- Clears marker and search state when `dataIndex < 2`.

### User Experience

- User can click on the map or search for an address to place a marker.
- Repeated actions update the marker position accordingly.
- After searching for an address, the input is cleared to indicate the result is applied.
- When switching to a non-inflow/outflow view, the marker and results are reset.

