### PR TITLE
Handle null NumInfected in outbreak label formatting

### DIFF
--- a/src/components/OutbreakPoints.tsx
+++ b/src/components/OutbreakPoints.tsx
@@ -63,7 +63,7 @@ export function loadOutbreaks() {
             yearsAgo: thisYear - year,
             week: monthDayToWeek(month, day),
             geoLoc: [outbreak.GeoLoc[0], outbreak.GeoLoc[1]],
-            label: `${outbreak.Confirmed}: ${outbreak.Production} (${outbreak.NumInfected})`,
+            label: `${outbreak.Confirmed}: ${outbreak.Production}${outbreak.NumInfected ? ` (${outbreak.NumInfected})` : ''}`,
         });
     });
 }


### PR DESCRIPTION
Update label formatting to safely handle cases where `NumInfected` is null.